### PR TITLE
Bugfix no description

### DIFF
--- a/cjenkins.py
+++ b/cjenkins.py
@@ -7,7 +7,7 @@ import curses
 import urllib
 import sys
 import time
-
+import traceback
 def createHeader():
 
 	header = "Curses Jenkins"
@@ -72,6 +72,7 @@ def displayGui():
 
 	except (KeyboardInterrupt, SystemExit, Exception):
 		curses.endwin()
+                print traceback.format_exc()
 		sys.exit(0)
 
 

--- a/cjenkins.py
+++ b/cjenkins.py
@@ -128,6 +128,9 @@ def addHealthReport(current, row):
 def addDescription(description, row):
 
 	# We just allow 1 line of description
+        if description is None:
+            description = "Jenkins"
+
 	description = description.split('\n')[0]
 
 	# If description is to long, cut of parts of the end


### PR DESCRIPTION
Looks like our jenkins servers did not produce a description which caused the script to crash without any trace of why. I have added print stack trace when something goes wrong and fixed the problem when no description provided by using a default value